### PR TITLE
Lazy geometry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@
 
 source "http://rubygems.org"
 
+gemspec
+
 group(:test) do
   gem('rake', '>= 0.9.2')
   gem('ffi-geos', '>= 0.0.4')

--- a/Rakefile
+++ b/Rakefile
@@ -64,10 +64,8 @@ platform_ =
 platform_suffix_ =
   case platform_
   when :mri
-    if ::RUBY_VERSION =~ /^1\.8\..*$/
-      'mri18'
-    elsif ::RUBY_VERSION =~ /^1\.9\..*$/
-      'mri19'
+    if ::RUBY_VERSION =~ /^(\d)\.(\d).*/
+      "mri#{$1}#{$2}".tap { |s| puts s }
     else
       raise "Unknown version of Matz Ruby Interpreter (#{::RUBY_VERSION})"
     end
@@ -75,7 +73,6 @@ platform_suffix_ =
   when :jruby then 'jruby'
   else 'unknown'
   end
-
 
 # Directories
 

--- a/rgeo-shapefile.gemspec
+++ b/rgeo-shapefile.gemspec
@@ -52,4 +52,5 @@
   s_.platform = ::Gem::Platform::RUBY
   s_.add_dependency('rgeo', '>= 0.3.13')
   s_.add_dependency('dbf', '>= 1.7.0')
+  s_.add_dependency('promise')
 end


### PR DESCRIPTION
I've been using this locally so that I can skip over irrelevant shapes without having to parse the whole geometry.  Also a tweak to allow tests to run on Ruby 2
