### PR TITLE
let `RGeo::Shapefile::Reader.open` return the block's value

### DIFF
--- a/lib/rgeo/shapefile/reader.rb
+++ b/lib/rgeo/shapefile/reader.rb
@@ -115,6 +115,7 @@ module RGeo
       #
       # If you provide a block, the shapefile reader will be yielded to
       # the block, and automatically closed at the end of the block.
+      # In this instance, File.open returns the value of the block.
       # If you do not provide a block, the shapefile reader will be
       # returned from this call. It is then the caller's responsibility
       # to close the reader when it is done.
@@ -169,7 +170,6 @@ module RGeo
           ensure
             file_.close
           end
-          nil
         else
           file_
         end

--- a/test/shapelib_cases_test.rb
+++ b/test/shapelib_cases_test.rb
@@ -13,6 +13,14 @@ module RGeo
         end
 
 
+        def test_open_with_block_returns_value_of_block
+          result = _open_shapefile('test') do |file_|
+            file_.num_records
+          end
+          assert_equal(3, result)
+        end
+
+
         def test_rewind
           _open_shapefile('test') do |file_|
             assert_equal(0, file_.cur_index)


### PR DESCRIPTION
if a block as been passed. This makes this method's behavior more consistent with other 'open' methods in Ruby, such as [`File.open`](http://ruby-doc.org/core-2.2.2/File.html#method-c-open).