### PR TITLE
convert Reader.open path argument to string

### DIFF
--- a/lib/rgeo/shapefile/reader.rb
+++ b/lib/rgeo/shapefile/reader.rb
@@ -173,7 +173,7 @@ module RGeo
       # block. You should use Reader::open instead.
 
       def initialize(path_, opts_ = {}) # :nodoc:
-        path_ = path_.sub(/\.shp$/, "")
+        path_ = path_.to_s.sub(/\.shp$/, "")
         @base_path = path_
         @opened = true
         @main_file = ::File.open(path_ + ".shp", "rb:ascii-8bit")


### PR DESCRIPTION
Chained a `.to_s` call onto the `path_` arg of `RGeo::Reader.open` to convert the arg to a string and make behavior in rails apps more consistent with other file readers e.g. `File.read` ; `File.open` which allow you to pass `Rails.root.join('filename')` as an argument.

I was getting file not found errors when passing `Rails.root.join` as an arg and fixed it by appending `.to_s`

This patch adds that `.to_s` call in the `RGeo::Reader.open` method definition. All tests pass and the behavior works as expected for me.