### PR TITLE
Add Enumerable to the Reader

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+### Current
+
+* Add Enumerable to the Reader (#40, x4d3)
+
 ### 3.0.0 / 2020-08-02
 
 * Handle invalid DBF file (#37, rywall)

--- a/History.md
+++ b/History.md
@@ -1,44 +1,44 @@
 ### Current
 
-* Add Enumerable to the Reader (#40, x4d3)
+* Add Enumerable to the Reader ([#40](https://github.com/rgeo/rgeo-shapefile/pull/40), x4d3)
 
 ### 3.0.0 / 2020-08-02
 
-* Handle invalid DBF file (#37, rywall)
-* Update DBF gem to version 4.x, bump minimum Ruby version to 2.4 (#38, alvir)
+* Handle invalid DBF file ([#37](https://github.com/rgeo/rgeo-shapefile/pull/37), rywall)
+* Update DBF gem to version 4.x, bump minimum Ruby version to 2.4 ([#38](https://github.com/rgeo/rgeo-shapefile/pull/38), alvir)
 
 ### 2.0.1 / 2019-04-01
 
-* Check dbf record attributes / allow DBF file to have fewer records than SHX (#34, womanonrails / #28, marcisv)
+* Check dbf record attributes / allow DBF file to have fewer records than SHX ([#34](https://github.com/rgeo/rgeo-shapefile/pull/34), womanonrails / [#28](https://github.com/rgeo/rgeo-shapefile/pull/28), marcisv)
 
 
 ### 2.0.0 / 2019-02-23
 
-* Use .cpg file to specify the DBF encoding (#32, rywall)
+* Use .cpg file to specify the DBF encoding ([#32](https://github.com/rgeo/rgeo-shapefile/pull/32), rywall)
 * Remove :dbf_encoding option introduced in 1.2.0
 
 
 ### 1.2.0 / 2019-02-21
 
-* Add ability to specify the DBF encoding (#30, rywall)
+* Add ability to specify the DBF encoding ([#30](https://github.com/rgeo/rgeo-shapefile/pull/30), rywall)
 
 
 ### 1.1.0 / 2018-11-30
 
-* Allow rgeo 2.0 (#29, sunpoet)
+* Allow rgeo 2.0 ([#29](https://github.com/rgeo/rgeo-shapefile/pull/29), sunpoet)
 * Require ruby 2.3+
 
 
 ### 1.0.0 / 2018-3-6
 
-* Require rgeo 1.0 (#27)
+* Require rgeo 1.0 ([#27](https://github.com/rgeo/rgeo-shapefile/pull/27))
 * Freeze strings
 
 
 ### 0.4.2 / 2017-1-31
 
 * Require ruby 2.1+
-* Handle non-string path objects in Reader (#20, msimonborg)
+* Handle non-string path objects in Reader ([#20](https://github.com/rgeo/rgeo-shapefile/pull/20), msimonborg)
 
 ### 0.4.1 / 2015-2-8
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ RGeo::Shapefile::Reader.open('myshpfil.shp') do |file|
     puts "  Geometry: #{record.geometry.as_text}"
     puts "  Attributes: #{record.attributes.inspect}"
   end
-  file.rewind
   record = file.next
   puts "First record geometry was: #{record.geometry.as_text}"
 end

--- a/lib/rgeo/shapefile/reader.rb
+++ b/lib/rgeo/shapefile/reader.rb
@@ -92,6 +92,7 @@ module RGeo
     #   a GeometryCollection instead of a MultiPolygon.
 
     class Reader
+      include Enumerable
       # Values less than this value are considered "no value" in the
       # shapefile format specification.
       NODATA_LIMIT = -1e38

--- a/lib/rgeo/shapefile/reader.rb
+++ b/lib/rgeo/shapefile/reader.rb
@@ -269,6 +269,7 @@ module RGeo
       def num_records
         @opened ? @num_records : nil
       end
+
       alias size num_records
 
       # Returns the shape type code.
@@ -343,8 +344,17 @@ module RGeo
       # and yield the Reader::Record for each one.
 
       def each
-        return unless @opened
-        yield _read_next_record while @cur_record_index < @num_records
+        return to_enum(:each) { @num_records } unless block_given?
+        raise IOError, "File was not open" unless @opened
+        # Each needs to be idempotent, therefore we reset all the internal indexes to their original value
+        current_record_index = @cur_record_index
+        begin
+          rewind
+          yield _read_next_record while @cur_record_index < @num_records
+        ensure
+          seek_index(current_record_index)
+        end
+        self
       end
 
       # Seek to the given record index.

--- a/test/shapelib_cases_test.rb
+++ b/test/shapelib_cases_test.rb
@@ -462,6 +462,16 @@ class ShapelibCasesTest < Minitest::Test
     end
   end
 
+  # Test that the reader is enumerable and test that least one method is implemented (each_slice)
+  def test_enumerable
+    _open_shapefile("test") do |file_|
+      assert(file_.class.include?(Enumerable))
+      file_.each_slice(10).each do |slice|
+        assert(slice.count < 11)
+      end
+    end
+  end
+
   private
 
   def _open_shapefile(name_, &block_)

--- a/test/shapelib_cases_test.rb
+++ b/test/shapelib_cases_test.rb
@@ -462,13 +462,39 @@ class ShapelibCasesTest < Minitest::Test
     end
   end
 
-  # Test that the reader is enumerable and test that least one method is implemented (each_slice)
+  # Test that the reader is enumerable
   def test_enumerable
-    _open_shapefile("test") do |file_|
-      assert(file_.class.include?(Enumerable))
-      file_.each_slice(10).each do |slice|
-        assert(slice.count < 11)
+    _open_shapefile("test") do |file|
+      # Test that each is idempotent and that the current_index is preserved
+      first = file.next
+      assert_equal(file.first.attributes, first.attributes)
+      assert_equal(first.index, 0)
+      assert_equal(first.attributes["Descriptio"], "Square with triangle missing")
+
+      second = file.next
+      assert_equal(file.take(2).last.attributes, second.attributes)
+      assert_equal(second.index, 1)
+      assert_equal(second.attributes["Descriptio"], "Smaller triangle")
+
+      # check that even if an exception occurred during .each, the current_index is preserved
+      was_caught = false
+      begin
+        file.each do
+          raise "oh no"
+        end
+      rescue StandardError => e
+        assert_equal(e.message, "oh no")
+        was_caught = true
       end
+      assert(was_caught)
+
+      third = file.next
+      assert_equal(file.to_a[2].attributes, third.attributes)
+      assert_equal(third.index, 2)
+      assert_equal(third.attributes["Descriptio"], "")
+
+      assert_equal(file.each.size, 3)
+      assert(file.class.include?(Enumerable))
     end
   end
 


### PR DESCRIPTION
As the reader is already implementing `.each`, it would be a shame to not be an `Enumerable` 

https://apidock.com/ruby/Enumerable