### PR TITLE
option to allow calling RGeo "unsafe_" methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ RGeo::Shapefile::Reader.open('myshpfil.shp') do |file|
   puts "First record geometry was: #{record.geometry.as_text}"
 end
 ```
+### Skipping validity checks
 
+If you have shapefiles that are failing [rgeo validity checks](https://github.com/rgeo/rgeo/blob/main/doc/Geometry-Validity.md) you can skip validity checks by passing `allow_unsafe_methods: true` to the `RGeo::Shapefile::Reader#open` method:
+
+```ruby
+RGeo::Shapefile::Reader.open('myshpfil.shp', allow_unsafe_methods: true) do |file|
+  # ...
+end
+```
 ## Install
 
 `RGeo::Shapefile` has the following requirements:

--- a/lib/rgeo/shapefile/reader.rb
+++ b/lib/rgeo/shapefile/reader.rb
@@ -633,7 +633,7 @@ module RGeo
                 # remaining polygons and check their outer rings.
                 unless parent_index_
                   polygons_.each_with_index do |poly_data_, index_|
-                    if index_ != first_try_ && part_data_[2].within?(poly_data_.first[2])
+                    if index_ != first_try_ && part_data_[2].public_send(@opts[:allow_unsafe_methods] ? :unsafe_within? : :within?, poly_data_.first[2])
                       parent_index_ = index_
                       break
                     end

--- a/lib/rgeo/shapefile/reader.rb
+++ b/lib/rgeo/shapefile/reader.rb
@@ -230,7 +230,7 @@ module RGeo
         @factory_supports_m = @factory.property(:has_m_coordinate)
 
         @assume_inner_follows_outer = opts_[:assume_inner_follows_outer]
-        @reader_opts = opts_
+        # @reader_opts = opts_
       end
 
       # Close the shapefile.
@@ -626,21 +626,7 @@ module RGeo
                 # The initial guess. It could be -1 if this inner ring
                 # appeared before any outer rings had appeared.
                 first_try_ = part_data_[3]
-                if first_try_ >= 0
-                  begin
-                    if part_data_[2].within?(polygons_[first_try_].first[2])
-                      parent_index_ = first_try_
-                    end
-                  rescue RGeo::Error::InvalidGeometry => invalid_geometry_error
-                    if Array.wrap(@reader_opts[:allow_unsafe_methods]).include?(:within)
-                      if part_data_[2].unsafe_within?(polygons_[first_try_].first[2])
-                        parent_index_ = first_try_
-                      end
-                    else
-                      raise invalid_geometry_error
-                    end
-                  end
-                end
+                if first_try_ >= 0 && part_data_[2].public_send(@opts_[:allow_unsafe_methods] ? :unsafe_within? : :within?, polygons_[first_try_].first[2])
                 # If the initial guess didn't work, go through the
                 # remaining polygons and check their outer rings.
                 unless parent_index_
@@ -777,7 +763,7 @@ module RGeo
                 outer_index_ = 0
                 geos_polygons_.each_with_index do |poly_, idx_|
                   if outer_poly_
-                    if poly_.contains?(outer_poly_)
+                    if poly_.public_send(@opts_[:allow_unsafe_methods] ? :unsafe_contains? : :contains?, outer_poly_)
                       outer_poly_ = poly_
                       outer_index_ = idx_
                       break

--- a/lib/rgeo/shapefile/reader.rb
+++ b/lib/rgeo/shapefile/reader.rb
@@ -176,6 +176,7 @@ module RGeo
       # block. You should use Reader::open instead.
 
       def initialize(path_, opts_ = {}) # :nodoc:
+        @opts = opts_
         path_ = path_.to_s.sub(/\.shp$/, "")
         @base_path = path_
         @opened = true
@@ -230,7 +231,6 @@ module RGeo
         @factory_supports_m = @factory.property(:has_m_coordinate)
 
         @assume_inner_follows_outer = opts_[:assume_inner_follows_outer]
-        # @reader_opts = opts_
       end
 
       # Close the shapefile.

--- a/lib/rgeo/shapefile/reader.rb
+++ b/lib/rgeo/shapefile/reader.rb
@@ -627,6 +627,8 @@ module RGeo
                 # appeared before any outer rings had appeared.
                 first_try_ = part_data_[3]
                 if first_try_ >= 0 && part_data_[2].public_send(@opts_[:allow_unsafe_methods] ? :unsafe_within? : :within?, polygons_[first_try_].first[2])
+                  parent_index_ = first_try_
+                end
                 # If the initial guess didn't work, go through the
                 # remaining polygons and check their outer rings.
                 unless parent_index_

--- a/lib/rgeo/shapefile/reader.rb
+++ b/lib/rgeo/shapefile/reader.rb
@@ -626,7 +626,7 @@ module RGeo
                 # The initial guess. It could be -1 if this inner ring
                 # appeared before any outer rings had appeared.
                 first_try_ = part_data_[3]
-                if first_try_ >= 0 && part_data_[2].public_send(@opts_[:allow_unsafe_methods] ? :unsafe_within? : :within?, polygons_[first_try_].first[2])
+                if first_try_ >= 0 && part_data_[2].public_send(@opts[:allow_unsafe_methods] ? :unsafe_within? : :within?, polygons_[first_try_].first[2])
                   parent_index_ = first_try_
                 end
                 # If the initial guess didn't work, go through the
@@ -765,7 +765,7 @@ module RGeo
                 outer_index_ = 0
                 geos_polygons_.each_with_index do |poly_, idx_|
                   if outer_poly_
-                    if poly_.public_send(@opts_[:allow_unsafe_methods] ? :unsafe_contains? : :contains?, outer_poly_)
+                    if poly_.public_send(@opts[:allow_unsafe_methods] ? :unsafe_contains? : :contains?, outer_poly_)
                       outer_poly_ = poly_
                       outer_index_ = idx_
                       break


### PR DESCRIPTION
I had some shapefiles that were throwing `RGeo::Error::InvalidGeometry` errors on polygons that seem to be valid (PostGIS accepts them in a `geometry` column and they can be imported using the `shp2pgsql` successfully and visualized on a map).

`rgeo` has some `unsafe_*` variants of methods available (like `unsafe_within?` instead of `within?`) mentioned here: 
https://github.com/rgeo/rgeo/blob/main/NEWS.md#validity-handling

This PR adds an `allow_unsafe_methods` option to the `RGeo::Shapefile::Reader#open` method that accepts a list of acceptable `unsafe_*` methods to call.  I implemented the option and support for just the `:within` method since that's all that was needed to fix the issue with my specific shapefile polygons, but it could be expanded to the other spatial methods as needed.

```
RGeo::Shapefile::Reader.open(file, allow_unsafe_methods: :within) do |shapefile|
   # ...
end
```

also supports array-style value for the option:

```
RGeo::Shapefile::Reader.open(file, allow_unsafe_methods: [:within]) do |shapefile|
   # ...
end
```
