### PR TITLE
Allow dbf 5.0+ as dependency

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,7 @@
 ### Current
 
+* Update DBF gem to allow version 5.0 ([#53](https://github.com/rgeo/rgeo-shapefile/pull/53), ilvez)
+
 ### 3.1.0 / 2023-09-30
 
 * Rubocop updates and execution ([#51](https://github.com/rgeo/rgeo-shapefile/pull/51), ObiWanKeoni)

--- a/rgeo-shapefile.gemspec
+++ b/rgeo-shapefile.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_dependency "rgeo", ">= 1.0"
-  spec.add_dependency "dbf", "~> 4.0"
+  spec.add_dependency "dbf", ">= 4.0", "< 6.0"
 
   spec.add_development_dependency "minitest", "~> 5.3"
   spec.add_development_dependency "rubocop", "~> 1.36.0"


### PR DESCRIPTION
dbf released [version 5.0.0](https://github.com/infused/dbf/blob/master/CHANGELOG.md#500) (and 5.0.1), which offer support for UTF-8 encoded columns.

I made dbf version required more loose, since 5.0 does not break any compatibility. I'm not library developer, so I don't know whether it's better to keep dependency versions more restricted or looser. In this case dbf 5.0 does not break compatibility in any way.